### PR TITLE
Bugfix/dotenv rails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,6 +63,4 @@ gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
 gem 'devise'
 
-gem 'dotenv-rails', groups: [:development, :test]
 gem 'cloudinary', '~> 1.16.0'
-


### PR DESCRIPTION
dontenv-rails was duplicated, we deleted the last one